### PR TITLE
Mark Alif Programming Language as EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Alif Programming Language
+
+___This application is no longer maintained.___
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "end-of-life": "This application is no longer maintained."
 }

--- a/org.aliflang.lang.yml
+++ b/org.aliflang.lang.yml
@@ -139,7 +139,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/alifcommunity/compiler.git
-        branch: flatpak-fork-unstable
         commit: f09b9a2cabf3f3a1907070d20874f14df4635b13
 
 
@@ -158,5 +157,4 @@ modules:
     sources: 
       - type: git
         url: https://github.com/alifcommunity/alifstudio.git
-        branch: flatpak-fork-unstable
         commit: 9e042b8dfe176065c2c7a2866ed105d7ee5ad6e3

--- a/org.aliflang.lang.yml
+++ b/org.aliflang.lang.yml
@@ -82,8 +82,8 @@ modules:
       - ./b2 install variant=release link=shared runtime-link=shared cxxflags="$CXXFLAGS" linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
-        sha256: 59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
+        url: https://github.com/boostorg/boost/archive/refs/tags/boost-1.72.0.tar.gz
+        sha256: cd9a10e1e8c21d3ae329701fa8d0675c40e26ac9948dc3c2e6a781f100f9843e
   
   
   - name: alif-lib


### PR DESCRIPTION
This **application** (Alif Studio IDE) uses an old runtime that was marked as end-of-life (EOL) three years ago.

There has been no development activity on the project (https://github.com/alifcommunity/alifstudio) for many years.

Hence, I marked this project as EOL.

Thanks.

```
$ LC_ALL=C flatpak remote-info flathub --system org.freedesktop.Sdk//19.08
End-of-life: The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. 
Date: 2021-09-17 20:55:13 +0000
```